### PR TITLE
add check to make sure ts is greater than last slot

### DIFF
--- a/plugin/src/plugin.rs
+++ b/plugin/src/plugin.rs
@@ -148,11 +148,17 @@ impl Inner {
 
         // Remove cached timestamp for the prev slot
         let prev_slot = slot - 1;
+        let last_ts = *self.unix_timestamps.get(&prev_slot).unwrap().value();
         self.unix_timestamps.remove(&prev_slot);
 
         // Process queues
         match self.clone().unix_timestamps.get(&slot) {
-            Some(entry) => self.process_queues_in_lookback_window(*entry.value()),
+            Some(entry) => {
+                if last_ts < *entry.value() {
+                    self.process_queues_in_lookback_window(*entry.value())?;
+                }
+                Ok(())
+            }
             None => Ok(()),
         }
     }


### PR DESCRIPTION
- this fixes the issue where the `process_queues_in_lookback_window` function will be executed twice because two slots have the same ts 
<img width="697" alt="Screen Shot 2022-05-23 at 5 35 26 PM" src="https://user-images.githubusercontent.com/20745708/169915614-4b706e56-e818-42b8-a341-3d17873818d1.png">

- new slot != a new unix ts
<img width="1394" alt="image" src="https://user-images.githubusercontent.com/20745708/169915716-609b2af6-fc38-4266-ab45-42c9f9dff807.png">
