### PR TITLE
Release workflow for Cronos Plugin

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,60 @@
+on:
+  push:
+    tags:
+      - "v*"
+  pull_request:
+    paths:
+      - ".github/workflows/release.yml"
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set env vars
+        run: |
+          source scripts/ci/rust-version.sh
+          echo "RUST_STABLE=$rust_stable" | tee -a $GITHUB_ENV
+
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ env.RUST_STABLE }}
+          override: true
+          profile: minimal
+          components: rustfmt
+
+      - name: Check Solana version
+        run: |
+          echo "CI_TAG=${GITHUB_REF#refs/*/}" >> "$GITHUB_ENV"
+          echo "CI_OS_NAME=linux" >> "$GITHUB_ENV"
+
+          SOLANA_VERSION="$(./scripts/ci/solana-version.sh)"
+          SOLANA_VERSION="v${SOLANA_VERSION#=}"
+          echo "SOLANA_VERSION=$SOLANA_VERSION" >> "$GITHUB_ENV"
+
+      - name: Grant permissions to create-tarball.sh
+        run: chmod +x ./scripts/ci/create-tarball.sh
+
+      - name: Grant permissions to cargo-install-all.sh
+        run: chmod +x ./scripts/ci/cargo-install-all.sh
+
+      - name: install libudev-dev
+        run: sudo apt-get install libudev-dev
+
+      - name: Build release tarball
+        run: ./scripts/ci/create-tarball.sh
+
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          body: |
+            cronos-geyser-plugin ${{ env.CI_TAG }}
+            solana ${{ env.SOLANA_VERSION }}
+            rust ${{ env.RUST_STABLE }}
+          files: |
+            cronos-geyser-plugin-release-*

--- a/scripts/ci/cargo-install-all.sh
+++ b/scripts/ci/cargo-install-all.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+
+set -e
+
+usage() {
+  exitcode=0
+  if [[ -n "$1" ]]; then
+    exitcode=1
+    echo "Error: $*"
+  fi
+  cat <<EOF
+usage: $0 [+<cargo version>] [--debug] <install directory>
+EOF
+  exit $exitcode
+}
+
+case "$CI_OS_NAME" in
+osx)
+  libExt=dylib
+  ;;
+linux)
+  libExt=so
+  ;;
+*)
+  echo CI_OS_NAME unsupported
+  exit 1
+  ;;
+esac
+
+maybeRustVersion=
+installDir=
+buildVariant=release
+maybeReleaseFlag=--release
+
+while [[ -n $1 ]]; do
+  if [[ ${1:0:1} = - ]]; then
+    if [[ $1 = --debug ]]; then
+      maybeReleaseFlag=
+      buildVariant=debug
+      shift
+    else
+      usage "Unknown option: $1"
+    fi
+  elif [[ ${1:0:1} = \+ ]]; then
+    maybeRustVersion=$1
+    shift
+  else
+    installDir=$1
+    shift
+  fi
+done
+
+if [[ -z "$installDir" ]]; then
+  usage "Install directory not specified"
+  exit 1
+fi
+
+installDir="$(mkdir -p "$installDir"; cd "$installDir"; pwd)"
+
+echo "Install location: $installDir ($buildVariant)"
+
+cd "$(dirname "$0")"/../..
+
+SECONDS=0
+
+mkdir -p "$installDir/lib"
+
+(
+  set -x
+  # shellcheck disable=SC2086 # Don't want to double quote $rust_version
+  cargo $maybeRustVersion build $maybeReleaseFlag --lib
+)
+
+cp -fv "target/$buildVariant/libcronos_plugin.$libExt" "$installDir"/lib/
+
+echo "Done after $SECONDS seconds"

--- a/scripts/ci/create-tarball.sh
+++ b/scripts/ci/create-tarball.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+set -e
+
+cd "$(dirname "$0")/../.."
+
+case "$CI_OS_NAME" in
+osx)
+  _cputype="$(uname -m)"
+  if [[ $_cputype = arm64 ]]; then
+    _cputype=aarch64
+  fi
+  TARGET=${_cputype}-apple-darwin
+  ;;
+linux)
+  TARGET=x86_64-unknown-linux-gnu
+  ;;
+*)
+  echo CI_OS_NAME unsupported
+  exit 1
+  ;;
+esac
+
+RELEASE_BASENAME="${RELEASE_BASENAME:=cronos-geyser-plugin-release}"
+TARBALL_BASENAME="${TARBALL_BASENAME:="$RELEASE_BASENAME"}"
+
+echo --- Creating release tarball
+(
+  set -x
+  rm -rf "${RELEASE_BASENAME:?}"/
+  mkdir "${RELEASE_BASENAME}"/
+
+  COMMIT="$(git rev-parse HEAD)"
+
+  (
+    echo "channel: $CI_TAG"
+    echo "commit: $COMMIT"
+    echo "target: $TARGET"
+  ) > "${RELEASE_BASENAME}"/version.yml
+
+  # Make CHANNEL available to include in the software version information
+  export CHANNEL
+
+  var=$(pwd)
+  echo "The current working directory $var."
+
+  source ./scripts/ci/rust-version.sh stable
+  ./scripts/ci/cargo-install-all.sh stable "${RELEASE_BASENAME}"
+
+  tar cvf "${TARBALL_BASENAME}"-$TARGET.tar "${RELEASE_BASENAME}"
+  bzip2 "${TARBALL_BASENAME}"-$TARGET.tar
+  cp "${RELEASE_BASENAME}"/version.yml "${TARBALL_BASENAME}"-$TARGET.yml
+)
+
+echo --- ok

--- a/scripts/ci/rust-version.sh
+++ b/scripts/ci/rust-version.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+
+# Source:
+# https://github.com/solana-labs/solana-accountsdb-plugin-postgres/blob/master/ci/rust-version.sh
+
+#
+# This file maintains the rust versions for use by CI.
+#
+# Obtain the environment variables without any automatic toolchain updating:
+#   $ source ci/rust-version.sh
+#
+# Obtain the environment variables updating both stable and nightly, only stable, or
+# only nightly:
+#   $ source ci/rust-version.sh all
+#   $ source ci/rust-version.sh stable
+#   $ source ci/rust-version.sh nightly
+
+# Then to build with either stable or nightly:
+#   $ cargo +"$rust_stable" build
+#   $ cargo +"$rust_nightly" build
+#
+
+if [[ -n $RUST_STABLE_VERSION ]]; then
+  stable_version="$RUST_STABLE_VERSION"
+else
+  stable_version=1.59.0
+fi
+
+if [[ -n $RUST_NIGHTLY_VERSION ]]; then
+  nightly_version="$RUST_NIGHTLY_VERSION"
+else
+  nightly_version=2022-02-24
+fi
+
+
+export rust_stable="$stable_version"
+export rust_stable_docker_image=solanalabs/rust:"$stable_version"
+
+export rust_nightly=nightly-"$nightly_version"
+export rust_nightly_docker_image=solanalabs/rust-nightly:"$nightly_version"
+
+[[ -z $1 ]] || (
+  rustup_install() {
+    declare toolchain=$1
+    if ! cargo +"$toolchain" -V > /dev/null; then
+      echo "$0: Missing toolchain? Installing...: $toolchain" >&2
+      rustup install "$toolchain"
+      cargo +"$toolchain" -V
+    fi
+  }
+
+  set -e
+  cd "$(dirname "${BASH_SOURCE[0]}")"
+  case $1 in
+  stable)
+    rustup_install "$rust_stable"
+    ;;
+  nightly)
+    rustup_install "$rust_nightly"
+    ;;
+  all)
+    rustup_install "$rust_stable"
+    rustup_install "$rust_nightly"
+    ;;
+  *)
+    echo "$0: Note: ignoring unknown argument: $1" >&2
+    ;;
+  esac
+)

--- a/scripts/ci/solana-version.sh
+++ b/scripts/ci/solana-version.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+# Prints the Solana version.
+
+set -e
+
+cd "$(dirname "$0")/../../plugin"
+
+cargo read-manifest | jq -r '.dependencies[] | select(.name == "solana-geyser-plugin-interface") | .req'


### PR DESCRIPTION
GH Action that runs for every new tag which allows for the Cronos Plugin to be compiled into release-ready binaries for solana validators.

files added:
- `release.yaml`
- `rust-version.sh`
- `solana-version.sh`
- `cargo-install-all.sh`
- `create-tarball.sh`